### PR TITLE
PEP-484

### DIFF
--- a/src/docstring_factories/default.ts
+++ b/src/docstring_factories/default.ts
@@ -38,7 +38,8 @@ export class DefaultFactory extends BaseFactory {
         this.appendText("\nKeyword Arguments:\n");
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} {`);
-            this.appendPlaceholder("[type]");
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("} -- ");
             this.appendPlaceholder("[description]");
             this.appendText(` (default: {${kwarg.default}})\n`);

--- a/src/docstring_factories/default.ts
+++ b/src/docstring_factories/default.ts
@@ -26,7 +26,8 @@ export class DefaultFactory extends BaseFactory {
         this.appendText("\nArguments:\n");
         for (let arg of docstring.args) {
             this.appendText(`\t${arg.var} {`);
-            this.appendPlaceholder("[type]");
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("} -- ");
             this.appendPlaceholder("[description]");
             this.appendNewLine();
@@ -56,7 +57,8 @@ export class DefaultFactory extends BaseFactory {
     formatReturns(returns: interfaces.Returns) {
         this.appendText(`\n${returns.return_type}:\n`);
         this.appendText("\t");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendText(" -- ");
         this.appendPlaceholder("[description]");
         this.appendNewLine()

--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -37,8 +37,6 @@ export class GoogleFactory extends BaseFactory {
     }
 
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
-        console.log("kwargs")
-        console.log(docstring.kwargs)
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} (`);
             if (kwarg.type) {this.appendText(`${kwarg.type}`);}

--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -37,9 +37,12 @@ export class GoogleFactory extends BaseFactory {
     }
 
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
+        console.log("kwargs")
+        console.log(docstring.kwargs)
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} (`);
-            this.appendPlaceholder("[type]");
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText(`, optional): Defaults to ${kwarg.default}. `);
             this.appendPlaceholder("[description]");
             this.appendNewLine();

--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -28,7 +28,8 @@ export class GoogleFactory extends BaseFactory {
         }
         for (let arg of docstring.args) {
             this.appendText(`\t${arg.var} (`);
-            this.appendPlaceholder("[type]");
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("): ");
             this.appendPlaceholder("[description]");
             this.appendNewLine();
@@ -57,7 +58,8 @@ export class GoogleFactory extends BaseFactory {
     formatReturns(returns: interfaces.Returns) {
         this.appendText("\nReturns:\n");
         this.appendText("\t");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendText(": ");
         this.appendPlaceholder("[description]");
         this.appendNewLine();

--- a/src/docstring_factories/numpy.ts
+++ b/src/docstring_factories/numpy.ts
@@ -27,7 +27,8 @@ export class NumpyFactory extends BaseFactory {
 
         for (let arg of docstring.args) {
             this.appendText(arg.var + " : {")
-            this.appendPlaceholder("[type]")
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("}\n")
 
             this.appendText("\t")
@@ -64,7 +65,8 @@ export class NumpyFactory extends BaseFactory {
 
     formatReturns(returns: interfaces.Returns) {
         this.appendText("Returns\n-------\n");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
 
         this.appendText("\n\t");
         this.appendPlaceholder("[description]");

--- a/src/docstring_factories/numpy.ts
+++ b/src/docstring_factories/numpy.ts
@@ -40,7 +40,8 @@ export class NumpyFactory extends BaseFactory {
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
         for (let kwarg of docstring.kwargs) {
             this.appendText(kwarg.var + " : {")
-            this.appendPlaceholder("[type]")
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("}, optional\n")
 
             this.appendText("\t")

--- a/src/docstring_factories/sphinx.ts
+++ b/src/docstring_factories/sphinx.ts
@@ -27,7 +27,8 @@ export class SphinxFactory extends BaseFactory {
             this.appendNewLine()
 
             this.appendText(":type " + arg.var + ": ")
-            this.appendPlaceholder("[type]")
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendNewLine()
         }
     }
@@ -60,7 +61,8 @@ export class SphinxFactory extends BaseFactory {
         this.appendNewLine()
 
         this.appendText(":rtype: ");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendNewLine()
     }
 }

--- a/src/docstring_factories/sphinx.ts
+++ b/src/docstring_factories/sphinx.ts
@@ -41,7 +41,8 @@ export class SphinxFactory extends BaseFactory {
             this.appendNewLine()
 
             this.appendText(":param " + kwarg.var + ": ")
-            this.appendPlaceholder("[type]")
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText(", optional")
             this.appendNewLine()
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,10 +28,12 @@ export function activate(context: vs.ExtensionContext): void {
 
 function activateOnEnter(changeEvent: vs.TextDocumentChangeEvent) {
     if (vs.window.activeTextEditor.document !== changeEvent.document) return;
-    if (changeEvent.contentChanges[0].rangeLength !== 0) return;
+    // if (changeEvent.contentChanges[0].rangeLength !== 0) return;
 
-    if (changeEvent.contentChanges[0].text.replace(/ |\t|\r/g, "") === "\n") {
-        processEnter(changeEvent);
+    if (changeEvent.contentChanges[0]){
+        if (changeEvent.contentChanges[0].text.replace(/ |\t|\r/g, "") === "\n") {
+            processEnter(changeEvent);
+        }
     }
 }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -135,7 +135,7 @@ export class PythonParser {
                 // regex looks for pep-484 type annotations
                 // example: 'def foo(bar : str)' would match `bar`
                 // as variable name, and `str` as type.
-                regex = /([\w][\w,\d]*)(?:\s*:\s*([\w][\w,\d]*))?/;
+                regex = /([\w]*)(?:\s*:\s*([\w]*))?/;
                 let semantic_list = param.match(regex);
 
                 args.push({
@@ -150,13 +150,18 @@ export class PythonParser {
     private parseKeywordArguments(line: string) {
         let kwargs: KeywordArgument[] = [];
         let match: RegExpExecArray;
-        let regex: RegExp = /(\w+) *= *("\w+"|\w+)/g;
+        let regex: RegExp = / *(\w+) *(?:: *(\w+) *)?= *([^),]+)\s*/g;
+
+        console.log("line")
+        console.log(line)
 
         while ((match = regex.exec(line)) != null) {
+            console.log("match")
+            console.log(match)
             kwargs.push({
                 var: match[1],
-                default: match[2],
-                type: null
+                default: match[3],
+                type: match[2]
             });
         }
         return kwargs

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Argument, KeywordArgument, Decorator, Raises, Returns, DocstringParts } from './interfaces';
 import { includesFromArray, inArray } from './utils'
+import { connect } from 'tls';
 
 export class PythonParser {
 
@@ -32,6 +33,7 @@ export class PythonParser {
     public parseLines(document: vscode.TextDocument, position: vscode.Position) {
         let definition_lines: string[] = this.getDefinitionLines(document, position);
         let content_lines: string[] = this.getContentLines(document, position);
+        let function_lines: string[] = this.getFunctionLines(document, position);
 
         if (definition_lines.length == 0 || !/^\s*def /.test(definition_lines[0])) {
             // if no lines were found in definition or
@@ -44,7 +46,7 @@ export class PythonParser {
             args: this.parseArguments(definition_lines[0]),
             kwargs: this.parseKeywordArguments(definition_lines[0]),
             raises: this.parseRaises(content_lines),
-            returns: this.parseReturns(content_lines)
+            returns: this.parseReturns(function_lines)
         }
         return docstring_parts
     }
@@ -71,7 +73,7 @@ export class PythonParser {
         let line_num: number = position.line;
         let def_indentation: number = this.getIndentation(document.lineAt(line_num - 1));
 
-        while (line_num < document.lineCount - 1) {
+        while (line_num < document.lineCount) {
             let line: vscode.TextLine = document.lineAt(line_num);
             if (!line.isEmptyOrWhitespace) {
                 if (this.getIndentation(line) <= def_indentation) {
@@ -83,7 +85,19 @@ export class PythonParser {
             }
             line_num += 1;
         }
-        return content_lines;
+        return content_lines
+    }
+
+    private getFunctionLines(document: vscode.TextDocument, position: vscode.Position) {
+        let function_lines: string[] = [];
+
+        let definition_lines = this.getDefinitionLines(document, position);
+        let content_lines = this.getContentLines(document, position);
+
+        function_lines = function_lines.concat(definition_lines);
+        function_lines = function_lines.concat(content_lines);
+        
+        return function_lines
     }
 
     private getIndentation(line: vscode.TextLine) {
@@ -117,9 +131,16 @@ export class PythonParser {
 
         for (let param of param_list[1].split(/\s*,\s*/)) {
             if (!param.includes('=') && !inArray(param, excluded_args)) {
+
+                // regex looks for pep-484 type annotations
+                // example: 'def foo(bar : str)' would match `bar`
+                // as variable name, and `str` as type.
+                regex = /([\w][\w,\d]*)(?:\s*:\s*([\w][\w,\d]*))?/;
+                let semantic_list = param.match(regex);
+
                 args.push({
-                    var: param,
-                    type: null
+                    var: semantic_list[1],
+                    type: semantic_list[2]
                 });
             }
         }
@@ -156,10 +177,21 @@ export class PythonParser {
 
     private parseReturns(lines: string[]) {
         for (let line of lines) {
-            let match = /\s*(return|yield)\s+([\w."]+)/.exec(line);
-            if (match != null) {
+            // matches return type annotation
+            let annotation_match = /->\s*([^:]+?)\s*:/.exec(line);
+            if (annotation_match != null) {
                 let v: Returns = {
-                    return_type: (match[1] == "return") ? "Returns" : "Yields",
+                    return_type: "Returns",
+                    value_type: annotation_match[1]
+                };
+                return v;
+            }
+
+            // if no type annotations are given
+            let return_match = /\s*(return|yield)\s+([\w."]+)/.exec(line);
+            if (return_match != null) {
+                let v: Returns = {
+                    return_type: (return_match[1] == "return") ? "Returns" : "Yields",
                     value_type: null
                 };
                 return v;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -152,12 +152,7 @@ export class PythonParser {
         let match: RegExpExecArray;
         let regex: RegExp = / *(\w+) *(?:: *(\w+) *)?= *([^),]+)\s*/g;
 
-        console.log("line")
-        console.log(line)
-
         while ((match = regex.exec(line)) != null) {
-            console.log("match")
-            console.log(match)
             kwargs.push({
                 var: match[1],
                 default: match[3],


### PR DESCRIPTION
Implements PEP-484 typeguessing specifications as requested in [Issue #22](https://github.com/NilsJPWerner/autoDocstring/issues/22)

autoDocstring now generates docstrings like: 
```python
def foo(bar: str, foobar: list = []) -> str:
    """[summary]
    
    Args:
        bar (str): [description]
        foobar (list, optional): Defaults to []. [description]
    
    Returns:
        str: [description]
    """

    return True
```