### PR TITLE
Pep-484 & Pep-526 Support

### DIFF
--- a/src/docstring_factories/default.ts
+++ b/src/docstring_factories/default.ts
@@ -26,7 +26,8 @@ export class DefaultFactory extends BaseFactory {
         this.appendText("\nArguments:\n");
         for (let arg of docstring.args) {
             this.appendText(`\t${arg.var} {`);
-            this.appendPlaceholder("[type]");
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("} -- ");
             this.appendPlaceholder("[description]");
             this.appendNewLine();
@@ -37,7 +38,8 @@ export class DefaultFactory extends BaseFactory {
         this.appendText("\nKeyword Arguments:\n");
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} {`);
-            this.appendPlaceholder("[type]");
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("} -- ");
             this.appendPlaceholder("[description]");
             this.appendText(` (default: {${kwarg.default}})\n`);
@@ -56,7 +58,8 @@ export class DefaultFactory extends BaseFactory {
     formatReturns(returns: interfaces.Returns) {
         this.appendText(`\n${returns.return_type}:\n`);
         this.appendText("\t");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendText(" -- ");
         this.appendPlaceholder("[description]");
         this.appendNewLine()

--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -28,7 +28,8 @@ export class GoogleFactory extends BaseFactory {
         }
         for (let arg of docstring.args) {
             this.appendText(`\t${arg.var} (`);
-            this.appendPlaceholder("[type]");
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("): ");
             this.appendPlaceholder("[description]");
             this.appendNewLine();
@@ -38,7 +39,8 @@ export class GoogleFactory extends BaseFactory {
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} (`);
-            this.appendPlaceholder("[type]");
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText(`, optional): Defaults to ${kwarg.default}. `);
             this.appendPlaceholder("[description]");
             this.appendNewLine();
@@ -57,7 +59,8 @@ export class GoogleFactory extends BaseFactory {
     formatReturns(returns: interfaces.Returns) {
         this.appendText("\nReturns:\n");
         this.appendText("\t");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendText(": ");
         this.appendPlaceholder("[description]");
         this.appendNewLine();

--- a/src/docstring_factories/numpy.ts
+++ b/src/docstring_factories/numpy.ts
@@ -27,7 +27,8 @@ export class NumpyFactory extends BaseFactory {
 
         for (let arg of docstring.args) {
             this.appendText(arg.var + " : {")
-            this.appendPlaceholder("[type]")
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("}\n")
 
             this.appendText("\t")
@@ -39,7 +40,8 @@ export class NumpyFactory extends BaseFactory {
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
         for (let kwarg of docstring.kwargs) {
             this.appendText(kwarg.var + " : {")
-            this.appendPlaceholder("[type]")
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText("}, optional\n")
 
             this.appendText("\t")
@@ -64,7 +66,8 @@ export class NumpyFactory extends BaseFactory {
 
     formatReturns(returns: interfaces.Returns) {
         this.appendText("Returns\n-------\n");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
 
         this.appendText("\n\t");
         this.appendPlaceholder("[description]");

--- a/src/docstring_factories/sphinx.ts
+++ b/src/docstring_factories/sphinx.ts
@@ -27,7 +27,8 @@ export class SphinxFactory extends BaseFactory {
             this.appendNewLine()
 
             this.appendText(":type " + arg.var + ": ")
-            this.appendPlaceholder("[type]")
+            if (arg.type) {this.appendText(`${arg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendNewLine()
         }
     }
@@ -40,7 +41,8 @@ export class SphinxFactory extends BaseFactory {
             this.appendNewLine()
 
             this.appendText(":param " + kwarg.var + ": ")
-            this.appendPlaceholder("[type]")
+            if (kwarg.type) {this.appendText(`${kwarg.type}`);}
+            else {this.appendPlaceholder("[type]");}
             this.appendText(", optional")
             this.appendNewLine()
         }
@@ -60,7 +62,8 @@ export class SphinxFactory extends BaseFactory {
         this.appendNewLine()
 
         this.appendText(":rtype: ");
-        this.appendPlaceholder("[type]");
+        if (returns.value_type) {this.appendText(`${returns.value_type}`);}
+        else {this.appendPlaceholder("[type]");}
         this.appendNewLine()
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,10 +28,12 @@ export function activate(context: vs.ExtensionContext): void {
 
 function activateOnEnter(changeEvent: vs.TextDocumentChangeEvent) {
     if (vs.window.activeTextEditor.document !== changeEvent.document) return;
-    if (changeEvent.contentChanges[0].rangeLength !== 0) return;
+    // if (changeEvent.contentChanges[0].rangeLength !== 0) return;
 
-    if (changeEvent.contentChanges[0].text.replace(/ |\t|\r/g, "") === "\n") {
-        processEnter(changeEvent);
+    if (changeEvent.contentChanges[0]){
+        if (changeEvent.contentChanges[0].text.replace(/ |\t|\r/g, "") === "\n") {
+            processEnter(changeEvent);
+        }
     }
 }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -135,7 +135,7 @@ export class PythonParser {
                 // regex looks for pep-484 type annotations
                 // example: 'def foo(bar : str)' would match `bar`
                 // as variable name, and `str` as type.
-                regex = /([\w]*)(?:\s*:\s*([\w]*))?/;
+                regex = /([\w]*)(?:\s*:\s*([\w\[\]]*))?/;
                 let semantic_list = param.match(regex);
 
                 args.push({
@@ -150,7 +150,7 @@ export class PythonParser {
     private parseKeywordArguments(line: string) {
         let kwargs: KeywordArgument[] = [];
         let match: RegExpExecArray;
-        let regex: RegExp = / *(\w+) *(?:: *(\w+) *)?= *([^),]+)\s*/g;
+        let regex: RegExp = / *(\w+) *(?:: *([\w\[\]]+) *)?= *([^),]+)\s*/g;
 
         while ((match = regex.exec(line)) != null) {
             kwargs.push({


### PR DESCRIPTION
[#23](https://github.com/NilsJPWerner/autoDocstring/pull/23) extended to include Pep-526 as requested in  [#24](https://github.com/NilsJPWerner/autoDocstring/issues/24).

Example:
```Python
from typing import List

def my_func(a : List[str] =5, b: List[str], c: list, d: list=5 ):
    """[summary]
    
    Args:
        b (List[str]): [description]
        c (list): [description]
        a (List[str], optional): Defaults to 5. [description]
        d (list, optional): Defaults to 5 . [description]
    
    Returns:
        [type]: [description]
    """  
    return True

```