### PR TITLE
Fix numpy parameters docstring

### DIFF
--- a/src/docstring_factories/numpy.ts
+++ b/src/docstring_factories/numpy.ts
@@ -38,9 +38,17 @@ export class NumpyFactory extends BaseFactory {
             this.appendPlaceholder("[description]")
             this.appendNewLine()
         }
+
+        if (!docstring.kwargs.length) {
+            this.appendNewLine();
+        }
     }
 
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
+        if (!docstring.args.length) {
+            this.appendText("Parameters\n----------\n");
+        }
+
         for (let kwarg of docstring.kwargs) {
             this.appendText(kwarg.var + " : ")
             this.appendPlaceholder(`${kwarg.type}`)


### PR DESCRIPTION
Fixes docstring parameters generation for `numpy` style.

### Fixed issues:
* When only keyword arguments were present, the `Parameters` section was missing.
* If only normal arguments were present, there was no empty line between the `Parameters` section and the next one.