### PR TITLE
Handle case when there are no content changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ export function activate(context: vs.ExtensionContext): void {
 
 function activateOnEnter(changeEvent: vs.TextDocumentChangeEvent) {
     if (vs.window.activeTextEditor.document !== changeEvent.document) return;
+    if (changeEvent.contentChanges.length < 1) return;
     if (changeEvent.contentChanges[0].rangeLength !== 0) return;
 
     if (changeEvent.contentChanges[0].text.replace(/ |\t|\r/g, "") === "\n") {


### PR DESCRIPTION
Got the following in my log:

    log.ts:171   ERR Cannot read property 'rangeLength' of undefined: TypeError: Cannot read property 'rangeLength' of undefined
        at activateOnEnter (C:\Users\perpe\.vscode\extensions\njpwerner.autodocstring-0.2.1\out\src\extension.js:21:38)
        at context.subscriptions.push.vs.workspace.onDidChangeTextDocument.changeEvent (C:\Users\perpe\.vscode\extensions\njpwerner.autodocstring-0.2.1\out\src\extension.js:13:90)
        at e.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:96:764)
        at e.$acceptDirtyStateChanged (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:685:973)
        at e.$acceptModelSaved (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:685:723)
        at e._doInvokeHandler (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:636:832)
        at e._invokeHandler (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:636:550)
        at e._receiveRequest (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:635:631)
        at e._receiveOneMessage (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:635:400)
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:634:315
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:637:395
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:95:432
        at e.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:96:764)
        at Socket.<anonymous> (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:154:338)
        at emitOne (events.js:96:13)
        at Socket.emit (events.js:191:7)
        at readableAddChunk (_stream_readable.js:178:18)
        at Socket.Readable.push (_stream_readable.js:136:10)
        at Pipe.onread (net.js:560:20)

    log.ts:171   ERR Cannot read property 'text' of undefined: TypeError: Cannot read property 'text' of undefined
        at PythonExtension._onChange (C:\Users\perpe\.vscode\extensions\tht13.python-0.2.3\out\client\src\pythonMain.js:85:22)
        at e.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:96:784)
        at e.$acceptDirtyStateChanged (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:685:973)
        at e.$acceptModelSaved (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:685:723)
        at e._doInvokeHandler (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:636:832)
        at e._invokeHandler (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:636:550)
        at e._receiveRequest (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:635:631)
        at e._receiveOneMessage (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:635:400)
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:634:315
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:637:395
        at c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:95:432
        at e.fire (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:96:764)
        at Socket.<anonymous> (c:\Program Files\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:154:338)
        at emitOne (events.js:96:13)
        at Socket.emit (events.js:191:7)
        at readableAddChunk (_stream_readable.js:178:18)
        at Socket.Readable.push (_stream_readable.js:136:10)
        at Pipe.onread (net.js:560:20)