### PR TITLE
Fix typo in sphinx docstrings

### DIFF
--- a/src/docstring_factories/sphinx.ts
+++ b/src/docstring_factories/sphinx.ts
@@ -43,7 +43,7 @@ export class SphinxFactory extends BaseFactory {
             this.appendText(", defaults to " + kwarg.default)
             this.appendNewLine()
 
-            this.appendText(":param " + kwarg.var + ": ")
+            this.appendText(":type " + kwarg.var + ": ")
             this.appendPlaceholder(`${kwarg.type}`)
             this.appendText(", optional")
             this.appendNewLine()


### PR DESCRIPTION
Given the following function definition:
```
def foo(bar, baz=None):
    pass
```
autoDocstring will create an incorrect docstring of:
```
    """
    [summary]
    
    :param bar: [description]
    :type bar: [type]
    :param baz: [description], defaults to None
    :param baz: [type], optional
    """
```
Note `:param baz:` appears twice.

This PR addresses the typo in SphinxFactory that is causing this behavior.