### PR TITLE
 Fix Google-style kwargs

### DIFF
--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -46,8 +46,9 @@ export class GoogleFactory extends BaseFactory {
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} (`);
             this.appendPlaceholder(`${kwarg.type}`);
-            this.appendText(`, optional): Defaults to ${kwarg.default}. `);
+            this.appendText(`, optional): `);
             this.appendPlaceholder("[description]");
+            this.appendText(`. Defaults to ${kwarg.default}.`);
             this.appendNewLine();
         }
     }

--- a/src/docstring_factories/google.ts
+++ b/src/docstring_factories/google.ts
@@ -40,6 +40,9 @@ export class GoogleFactory extends BaseFactory {
     }
 
     formatKeywordArguments(docstring: interfaces.DocstringParts) {
+        if (docstring.args.length === 0 && docstring.kwargs.length > 0) {
+            this.appendText("\nArgs:\n");
+        }
         for (let kwarg of docstring.kwargs) {
             this.appendText(`\t${kwarg.var} (`);
             this.appendPlaceholder(`${kwarg.type}`);


### PR DESCRIPTION
This PR is for the Google style.
First commit adds the `Args` section header also when there are no args but only kwargs.
Second commit writes the default value after the description and not before, as is tradition.

#### Before

```python
def foobar(foo=True):
    """[summary]
        foo (bool, optional): Defaults to True. [description]
    """
    pass
```

#### After

```python
def foobar(foo=True):
    """[summary]
    
    Args:
        foo (bool, optional): [description]. Defaults to True.
    """
    pass
```