### PR TITLE
Add support for relative paths in `customTemplatePath` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cursor must be on the line directly below the definition to generate full auto-p
 This extension contributes the following settings:
 
 * `autoDocstring.docstringFormat`: Switch between different docstring formats
-* `autoDocstring.customTemplatePath`: Path to a custom docstring template
+* `autoDocstring.customTemplatePath`: Path to a custom docstring template (absolute or relative to the project root)
 * `autoDocstring.generateDocstringOnEnter`: Generate the docstring on pressing enter after opening docstring
 * `autoDocstring.includeExtendedSummary`: Include extended summary section in docstring
 * `autoDocstring.includeName`: Include function name at the start of docstring

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
                 "autoDocstring.customTemplatePath": {
                     "type": "string",
                     "default": "",
-                    "description": "Path to custom docstring template (overrides docstringFormat)"
+                    "description": "Path to custom docstring template (overrides docstringFormat). Path can be absolute or relative to the project root."
                 },
                 "autoDocstring.generateDocstringOnEnter": {
                     "type": "boolean",

--- a/src/autodocstring.ts
+++ b/src/autodocstring.ts
@@ -67,22 +67,21 @@ export class AutoDocstring {
         const config = vs.workspace.getConfiguration("autoDocstring");
         let customTemplatePath = config.get("customTemplatePath").toString();
 
-        if (customTemplatePath !== "") {
-
-            if (!path.isAbsolute(customTemplatePath)) {
-                customTemplatePath = path.join(vs.workspace.rootPath, customTemplatePath);
-            }
-
-            try {
-                return getCustomTemplate(customTemplatePath);
-            }
-            catch (err) {
-                const errorMessage = "AutoDocstring Error: Template could not be found: " + customTemplatePath;
-                vs.window.showErrorMessage(errorMessage);
-            }
-        } else {
+        if (customTemplatePath === "") {
             const docstringFormat = config.get("docstringFormat").toString();
             return getTemplate(docstringFormat);
+        }
+
+        if (!path.isAbsolute(customTemplatePath)) {
+            customTemplatePath = path.join(vs.workspace.rootPath, customTemplatePath);
+        }
+
+        try {
+            return getCustomTemplate(customTemplatePath);
+        }
+        catch (err) {
+            const errorMessage = "AutoDocstring Error: Template could not be found: " + customTemplatePath;
+            vs.window.showErrorMessage(errorMessage);
         }
     }
 }

--- a/src/autodocstring.ts
+++ b/src/autodocstring.ts
@@ -4,6 +4,8 @@ import { getCustomTemplate, getTemplate } from "./docstring/get_template";
 import { docstringIsClosed } from "./parse/closed_docstring";
 import { isMultiLineString } from "./parse/multi_line_string";
 import { parse } from "./parse/parse";
+import * as path from "path";
+
 
 export class AutoDocstring {
 
@@ -63,9 +65,14 @@ export class AutoDocstring {
 
     private getTemplate(): string {
         const config = vs.workspace.getConfiguration("autoDocstring");
-        const customTemplatePath = config.get("customTemplatePath").toString();
+        let customTemplatePath = config.get("customTemplatePath").toString();
 
         if (customTemplatePath !== "") {
+
+            if (!path.isAbsolute(customTemplatePath)) {
+                customTemplatePath = path.join(vs.workspace.rootPath, customTemplatePath);
+            }
+
             try {
                 return getCustomTemplate(customTemplatePath);
             }


### PR DESCRIPTION
This is simple solution for the issue I had (#72). This allows easier template sharing across the team, since there can be a template that is pushed to the project repository and referenced as a relative path.
Relative template path is resolved relative to the workspace root directory. Absolute path still works as before.
For example:
```
src/...
tests/...
requirements.txt
.pydoc_template
```

```
"autoDocstring.customTemplatePath": ".pydoc_template"
```

or

```
"autoDocstring.customTemplatePath": ".vscode/pydoc_template.txt"
```
 I didn't find any tests that need an update.