### PR TITLE
Fixes #59: Omit `-> None` return annotation

### DIFF
--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -83,7 +83,7 @@ function parseReturn(parameters: string[], body: string[]): Returns {
     return returnType;
 }
 
-function parseReturnFromDefinition(parameters: string[]): Returns {
+function parseReturnFromDefinition(parameters: string[]): Returns | undefined {
     const pattern = /^->\s*([\w\[\], \.]*)/;
 
     for (const param of parameters) {
@@ -93,7 +93,8 @@ function parseReturnFromDefinition(parameters: string[]): Returns {
             continue;
         }
 
-        return { type: match[1] };
+        // Skip "-> None" annotations
+        return match[1] === "None" ? undefined : { type: match[1] };
     }
 
     return undefined;

--- a/src/test/parse/parse_parameters.spec.ts
+++ b/src/test/parse/parse_parameters.spec.ts
@@ -79,6 +79,13 @@ describe("parseParameters()", () => {
         });
     });
 
+    it("should not parse '-> None' return types", () => {
+        const parameterTokens = ["-> None"];
+        const result = parseParameters(parameterTokens, [], "name");
+
+        expect(result.returns).to.deep.equal(undefined);
+    });
+
     it("should parse the return from the body if there is no return type in the definition", () => {
         const parameterTokens = ["param1"];
         const body = ["return 3"];


### PR DESCRIPTION
* Omit return statement when function is annonated `-> None`
* Added unit test