### PR TITLE
Cut release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.4.0] - 2019-11-01
+- Omit `-> None` return annotation (@HaaLeo)
+- Add support for relative paths in `customTemplatePath` configuration (@s-kovacevic)
+
 ## [0.3.0] - 2019-04-16
 - Switched to mustache.js for templating
 - Added support for custom templating

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "autodocstring",
-    "version": "0.2.3",
+    "version": "0.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -470,19 +470,6 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
-        "cross-spawn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
-            "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -553,27 +540,22 @@
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
-        "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-            "dev": true,
-            "requires": {
-                "once": "^1.4.0"
-            }
-        },
         "es-abstract": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+            "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
+                "has-symbols": "^1.0.0",
                 "is-callable": "^1.1.4",
                 "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
+                "object-inspect": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "string.prototype.trimleft": "^2.1.0",
+                "string.prototype.trimright": "^2.1.0"
             }
         },
         "es-to-primitive": {
@@ -613,21 +595,6 @@
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
-        },
-        "execa": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            }
         },
         "extend": {
             "version": "3.0.2",
@@ -711,15 +678,6 @@
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
-        },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dev": true,
-            "requires": {
-                "pump": "^3.0.0"
-            }
         },
         "getpass": {
             "version": "0.1.7",
@@ -866,16 +824,10 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
-        "invert-kv": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-            "dev": true
-        },
         "is-buffer": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+            "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
             "dev": true
         },
         "is-callable": {
@@ -945,9 +897,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -990,15 +942,6 @@
                 "verror": "1.10.0"
             }
         },
-        "lcid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^2.0.0"
-            }
-        },
         "locate-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1010,9 +953,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "log-symbols": {
@@ -1040,26 +983,6 @@
             "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
             "dev": true
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
-        "mem": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-            }
-        },
         "mime-db": {
             "version": "1.38.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
@@ -1074,12 +997,6 @@
             "requires": {
                 "mime-db": "~1.38.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -1106,9 +1023,9 @@
             }
         },
         "mocha": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.3.tgz",
-            "integrity": "sha512-QdE/w//EPHrqgT5PNRUjRVHy6IJAzAf1R8n2O8W8K2RZ+NbPfOD5cBDp+PGa2Gptep37C/TdBiaNwakppEzEbg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+            "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -1120,7 +1037,7 @@
                 "glob": "7.1.3",
                 "growl": "1.10.5",
                 "he": "1.2.0",
-                "js-yaml": "3.13.0",
+                "js-yaml": "3.13.1",
                 "log-symbols": "2.2.0",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
@@ -1131,9 +1048,9 @@
                 "supports-color": "6.0.0",
                 "which": "1.3.1",
                 "wide-align": "1.1.3",
-                "yargs": "13.2.2",
-                "yargs-parser": "13.0.0",
-                "yargs-unparser": "1.5.0"
+                "yargs": "13.3.0",
+                "yargs-parser": "13.1.1",
+                "yargs-unparser": "1.6.0"
             }
         },
         "ms": {
@@ -1146,12 +1063,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
             "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
-        },
-        "nice-try": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
         },
         "node-environment-flags": {
             "version": "1.0.5",
@@ -1194,6 +1105,12 @@
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
+        "object-inspect": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+            "dev": true
+        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1231,39 +1148,16 @@
                 "wrappy": "1"
             }
         },
-        "os-locale": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-            "dev": true,
-            "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-            }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
             "dev": true
         },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-            "dev": true
-        },
         "p-limit": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
             "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
@@ -1337,16 +1231,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
             "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
-        },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -1516,6 +1400,26 @@
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
             }
         },
         "string_decoder": {
@@ -1947,22 +1851,21 @@
             "dev": true
         },
         "yargs": {
-            "version": "13.2.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-            "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+            "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
+                "cliui": "^5.0.0",
                 "find-up": "^3.0.0",
                 "get-caller-file": "^2.0.1",
-                "os-locale": "^3.1.0",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
                 "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^13.0.0"
+                "yargs-parser": "^13.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1970,6 +1873,17 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
                 },
                 "string-width": {
                     "version": "3.1.0",
@@ -1990,13 +1904,24 @@
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
                 }
             }
         },
         "yargs-parser": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-            "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+            "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
@@ -2004,58 +1929,14 @@
             }
         },
         "yargs-unparser": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-            "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
             "dev": true,
             "requires": {
                 "flat": "^4.1.0",
-                "lodash": "^4.17.11",
-                "yargs": "^12.0.5"
-            },
-            "dependencies": {
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "12.0.5",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^3.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1 || ^4.0.0",
-                        "yargs-parser": "^11.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
-                    }
-                }
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
             }
         },
         "yn": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "autodocstring",
     "displayName": "autoDocstring",
     "description": "Generates python docstrings",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "publisher": "njpwerner",
     "license": "SEE LICENSE IN LICENSE",
     "icon": "images/icon.png",
@@ -125,7 +125,7 @@
         "@types/node": "^6.14.4",
         "chai": "^4.1.2",
         "copyfiles": "^2.1.0",
-        "mocha": "^6.1.3",
+        "mocha": "^6.2.2",
         "ts-node": "^4.1.0",
         "typescript": "^2.0.3",
         "vscode": "^1.1.28"


### PR DESCRIPTION
I cut you a release for 0.4.0. 

Mostly because I'm looking for relative path support for templates now that  #73 has landed, and figure if I did this all you need to do is publish. 

Changes in this PR:
1) Updated CHANGELOG.md
2) Bumped SemVer minor version to 0.4.0
3) Updated mocha to 6.2.2 as per `npm audit` results
4) Updated package-lock.json after 2) and 3)
5) Tested locally:

<details>
<summary>Local test result screenshots</summary>

![image](https://user-images.githubusercontent.com/11222441/68060722-ce802080-fcbe-11e9-8891-c37683e98667.png)

![image](https://user-images.githubusercontent.com/11222441/68060825-477f7800-fcbf-11e9-8802-9e48b13375c8.png)

</details>

