### PR TITLE
add google-simplified.mustache and sphinx-simplified.mustache

### DIFF
--- a/src/docstring/get_template.ts
+++ b/src/docstring/get_template.ts
@@ -1,11 +1,16 @@
+
 import {readFileSync} from "fs";
 
 export function getTemplate(docstringFormat: string): string {
     switch (docstringFormat) {
         case "google":
             return getTemplateFile("google.mustache");
+        case "google-simplified":
+            return getTemplateFile("google-simplified.mustache");
         case "sphinx":
             return getTemplateFile("sphinx.mustache");
+        case "sphinx-simplified":
+            return getTemplateFile("sphinx-simplified.mustache");
         case "numpy":
             return getTemplateFile("numpy.mustache");
         default:

--- a/src/docstring/templates/google-simplified.mustache
+++ b/src/docstring/templates/google-simplified.mustache
@@ -1,0 +1,29 @@
+{{! Google Docstring Template }}
+{{summaryPlaceholder}}
+{{#parametersExist}}
+Args:
+{{#args}}
+    {{var}} ({{typePlaceholder}}): {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+    {{var}} ({{typePlaceholder}}, optional): {{descriptionPlaceholder}}. Defaults to {{&default}}.
+{{/kwargs}}
+{{/parametersExist}}
+{{#exceptionsExist}}
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{/exceptionsExist}}
+{{#returnsExist}}
+Returns:
+{{#returns}}
+    {{typePlaceholder}}: {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+{{#yieldsExist}}
+Yields:
+{{#yields}}
+    {{typePlaceholder}}: {{descriptionPlaceholder}}
+{{/yields}}
+{{/yieldsExist}}

--- a/src/docstring/templates/sphinx-simplified.mustache
+++ b/src/docstring/templates/sphinx-simplified.mustache
@@ -1,0 +1,18 @@
+{{! Sphinx Docstring Template }}
+{{summaryPlaceholder}}
+{{#args}}
+:param {{var}}: ({{typePlaceholder}}): {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+:param {{var}}: ({{typePlaceholder}}, optional): {{descriptionPlaceholder}}, defaults to {{&default}}
+{{/kwargs}}
+{{#exceptions}}
+:raises {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{#returns}}
+:return: ({{typePlaceholder}}): {{descriptionPlaceholder}}
+{{/returns}}
+
+{{#yields}}
+:yield: ({{typePlaceholder}}): {{descriptionPlaceholder}}
+{{/yields}}


### PR DESCRIPTION
I delete extra blank lines for google format and save as "google-simplied", so that it seems look like better at least for me. An example in python  shown as following:
 '''[summary]
    Args:
        init_status ([type]): [description]
        aim_status ([type]): [description]
        x_width ([type]): [description]
        y_width ([type]): [description]
    Returns:
        [type]: [description]
'''
And also for sphinx:
'''[summary]
    :param init_status: ([type]): [description]
    :param aim_status: ([type]): [description]
    :param x_width: ([type]): [description]
    :param y_width: ([type]): [description]
    :return: ([type]): [description]
'''