### PR TITLE
Fix docstring generation on Windows

### DIFF
--- a/src/parse/valid_docstring_prefix.ts
+++ b/src/parse/valid_docstring_prefix.ts
@@ -4,7 +4,7 @@
  */
 export function validDocstringPrefix(document: string, linePosition: number,
                                      charPosition: number, quoteStyle: string): boolean {
-    const lines = document.split("\n");
+    const lines = document.split(/\r?\n/);
     const line = lines[linePosition];
     const prefix = line.slice(0, charPosition + 1);
 


### PR DESCRIPTION
Fixes #118.

CrLf line-ending support seemed to got lost somewhere recently :)