### PR TITLE
Correct indentation for missing body

### DIFF
--- a/src/generate_docstring.ts
+++ b/src/generate_docstring.ts
@@ -49,7 +49,7 @@ export class AutoDocstring {
         );
 
         const docstringParts = parse(document, position.line);
-        const indentation = getDocstringIndentation(document, position.line);
+        const indentation = getDocstringIndentation(document, position.line, position.character);
         const docstring = docstringFactory.generateDocstring(docstringParts, indentation);
 
         return new vs.SnippetString(docstring);

--- a/src/parse/get_docstring_indentation.ts
+++ b/src/parse/get_docstring_indentation.ts
@@ -15,5 +15,5 @@ export function getDocstringIndentation(document: string, linePosition: number):
         currentLineNum++;
     }
 
-    return "    ";
+    return "";
 }

--- a/src/parse/get_docstring_indentation.ts
+++ b/src/parse/get_docstring_indentation.ts
@@ -8,11 +8,8 @@ export function getDocstringIndentation(document: string, linePosition: number):
     while (currentLineNum < lines.length) {
         const line = lines[currentLineNum];
 
-        if (!blankLine(line)) {
-            const indentation = getIndentation(line);
-            if (indentation) {
-                return indentation;
-            }
+        if (!blankLine(line) && getIndentation(line)) {
+            return getIndentation(line);
         }
 
         currentLineNum++;

--- a/src/parse/get_docstring_indentation.ts
+++ b/src/parse/get_docstring_indentation.ts
@@ -1,6 +1,6 @@
 import { blankLine, getIndentation } from "./utilities";
 
-export function getDocstringIndentation(document: string, linePosition: number): string {
+export function getDocstringIndentation(document: string, linePosition: number, lineCharacter: number = 0): string {
     const lines = document.split("\n");
 
     let currentLineNum = linePosition;
@@ -15,5 +15,6 @@ export function getDocstringIndentation(document: string, linePosition: number):
         currentLineNum++;
     }
 
-    return "";
+    // Return current cursor indentation.
+    return Array(lineCharacter + 1).join(" ");
 }

--- a/src/parse/get_docstring_indentation.ts
+++ b/src/parse/get_docstring_indentation.ts
@@ -10,7 +10,7 @@ export function getDocstringIndentation(document: string, linePosition: number):
 
         if (!blankLine(line)) {
             const indentation = getIndentation(line);
-            if (indentation !== "") {
+            if (indentation) {
                 return indentation;
             }
         }

--- a/src/parse/get_docstring_indentation.ts
+++ b/src/parse/get_docstring_indentation.ts
@@ -9,11 +9,14 @@ export function getDocstringIndentation(document: string, linePosition: number):
         const line = lines[currentLineNum];
 
         if (!blankLine(line)) {
-            return getIndentation(line);
+            const indentation = getIndentation(line);
+            if (indentation !== "") {
+                return indentation;
+            }
         }
 
         currentLineNum++;
     }
 
-    return "";
+    return "    ";
 }

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -131,7 +131,7 @@ describe("Basic Integration Tests", function () {
                     "./python_test_files/file_5_output.py",
                 ),
                 inputFilePath: path.resolve(__dirname, "./python_test_files/file_5.py"),
-                position: new vsc.Position(2, 0),
+                position: new vsc.Position(5, 4),
             });
         });
     });

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -123,6 +123,17 @@ describe("Basic Integration Tests", function () {
                 position: new vsc.Position(5, 0),
             });
         });
+
+        it("Does not mess up empty function in file 5", async function () {
+            await testDocstringGeneration({
+                expectedOutputFilePath: path.resolve(
+                    __dirname,
+                    "./python_test_files/file_5_output.py",
+                ),
+                inputFilePath: path.resolve(__dirname, "./python_test_files/file_5.py"),
+                position: new vsc.Position(2, 0),
+            });
+        });
     });
 });
 

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -124,7 +124,7 @@ describe("Basic Integration Tests", function () {
             });
         });
 
-        it("Does not mess up empty function in file 5", async function () {
+        it("Correctly indents docstring for empty function in file 5", async function () {
             await testDocstringGeneration({
                 expectedOutputFilePath: path.resolve(
                     __dirname,

--- a/src/test/integration/python_test_files/file_5.py
+++ b/src/test/integration/python_test_files/file_5.py
@@ -1,2 +1,6 @@
 
 def function():
+
+
+def my_4_spaces_func(a1):
+    print("foo")

--- a/src/test/integration/python_test_files/file_5.py
+++ b/src/test/integration/python_test_files/file_5.py
@@ -1,6 +1,5 @@
 
-def function():
-
-
 def my_4_spaces_func(a1):
     print("foo")
+
+def function():

--- a/src/test/integration/python_test_files/file_5.py
+++ b/src/test/integration/python_test_files/file_5.py
@@ -1,0 +1,2 @@
+
+def function():

--- a/src/test/integration/python_test_files/file_5_output.py
+++ b/src/test/integration/python_test_files/file_5_output.py
@@ -1,0 +1,4 @@
+
+def function():
+    """[summary]
+    """

--- a/src/test/integration/python_test_files/file_5_output.py
+++ b/src/test/integration/python_test_files/file_5_output.py
@@ -1,7 +1,7 @@
 
+def my_4_spaces_func(a1):
+    print("foo")
+
 def function():
     """[summary]
     """
-
-def my_4_spaces_func(a1):
-    print("foo")

--- a/src/test/integration/python_test_files/file_5_output.py
+++ b/src/test/integration/python_test_files/file_5_output.py
@@ -2,3 +2,6 @@
 def function():
     """[summary]
     """
+
+def my_4_spaces_func(a1):
+    print("foo")

--- a/src/test/parse/get_docstring_indentation.spec.ts
+++ b/src/test/parse/get_docstring_indentation.spec.ts
@@ -31,10 +31,10 @@ describe("getDocstringIndentation()", () => {
         expect(result).to.equal("        ");
     });
 
-    it("should default to blank string if no indentation is found", () => {
+    it("should default to 4 spaces if no indentation is found", () => {
         const result = getDocstringIndentation("", 0);
-
-        expect(result).to.equal("");
+        // default should be 4 spaces
+        expect(result).to.equal("    ");
     });
 });
 

--- a/src/test/parse/get_docstring_indentation.spec.ts
+++ b/src/test/parse/get_docstring_indentation.spec.ts
@@ -31,10 +31,10 @@ describe("getDocstringIndentation()", () => {
         expect(result).to.equal("        ");
     });
 
-    it("should default to 4 spaces if no indentation is found", () => {
+    it("should default to blank string if no indentation is found", () => {
         const result = getDocstringIndentation("", 0);
-        // default should be 4 spaces
-        expect(result).to.equal("    ");
+
+        expect(result).to.equal("");
     });
 });
 


### PR DESCRIPTION
This attempts to address #117 and #130 (duplicate). I think the default indentation should be [4 spaces](https://www.python.org/dev/peps/pep-0008/#indentation), but I guess that's a matter of opinion. I've not really programmed in typescript, but I hope this works and is an appropriate fix for the problem :). Also the first line in any python file is almost always the import statements, which have no indentation... so I think the default behavior should be to search further down the file for lines that would actually be indented 🤷‍♂️ 