### PR TITLE
Fix: Parse quoted type hints in type guessing

### DIFF
--- a/src/parse/guess_type.ts
+++ b/src/parse/guess_type.ts
@@ -13,14 +13,14 @@ export function guessType(parameter: string): string {
 }
 
 function getTypeFromTyping(parameter: string): string {
-    const pattern = /\w+\s*:\s*(\w[\w\[\], \.]*)/;
+    const pattern = /\w+\s*:\s*(['"]?\w[\w\[\], \.]*['"]?)/;
     const typeHint = pattern.exec(parameter);
 
     if (typeHint == null || typeHint.length !== 2) {
         return undefined;
     }
 
-    return typeHint[1].trim();
+    return typeHint[1].replace(/['"]+/g, '').trim();
 }
 
 function guessTypeFromDefaultValue(parameter: string): string {

--- a/src/test/parse/guess_type.spec.ts
+++ b/src/test/parse/guess_type.spec.ts
@@ -15,6 +15,13 @@ describe("guessType()", () => {
             expect(result).to.equal("int");
         });
 
+        it("should get type from quoted arg type hint", () => {
+            const parameter = "arg: 'int'";
+            const result = guessType(parameter);
+
+            expect(result).to.equal("int");
+        });
+
         it("should get type from composite type hint", () => {
             const parameter = "arg: List[str]";
             const result = guessType(parameter);


### PR DESCRIPTION
## Description
As explained in #138 the ability to guess types from type hints was "broken" when it would encounter a quoted type hint as in the example below:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
	import pandas as pd

def foo(bar: "pd.DataFrame"):
	pass
```

Since quoted type hints aren't uncommon when the developer does not want to import a library and in the case of forward imports. I thought this might be a nice addition.

Without an ability to parse quoted hints, the docstring would fail to generate arguments with types resulting in the following:

```python
def foo(bar: "pd.DataFrame"):
	"""[summary]
	"""
```

## How was this tested?
- Ran ext in VSCode extention development. Tested the following cases"
`def foo(bar: pd.DataFrame):`, `def foo(bar: "pd.DataFrame"):`, `def foo(bar: 'pd.DataFrame'):`
All lead to:
```python
def foo(bar: "pd.DataFrame", is_something):
    """[summary]

    Args:
        bar (pd.DataFrame): [description]
        is_something: (bool): [description]
    """
```

## Note to reviewer
I didn't check other functionalities nor ran unit tests to check this change wasn't breaking anything as I'm not great at working in TypeScript or developing extensions in VSCode, but would be happy to run further tests on your guidance if required.

Also, I haven't checked whether there are any PEP conventions that would advise against documenting hints that are quoted, but I don't see why not.


## Related Issue
Fixes #138 