### PR TITLE
Fixes #143: Ignore "raise something" in comments

### DIFF
--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -133,7 +133,7 @@ function parseReturnFromDefinition(parameters: string[]): Returns | null {
 
 function parseExceptions(body: string[]): Exception[] {
     const exceptions: Exception[] = [];
-    const pattern = /raise\s+([\w.]+)/;
+    const pattern = /(?<!#.*)raise\s+([\w.]+)/;
 
     for (const line of body) {
         const match = line.match(pattern);

--- a/src/test/parse/parse_parameters.spec.ts
+++ b/src/test/parse/parse_parameters.spec.ts
@@ -192,6 +192,13 @@ describe("parseParameters()", () => {
         ]);
     });
 
+    it("should not parse exception after inline comment", () => {
+        const functionContent = ["arg1 + arg2 # todo: raise an error"];
+        const result = parseParameters([], functionContent, "");
+
+        expect(result.exceptions).to.eql([]);
+    });
+
     context("when the parameters have strange spacing", () => {
         it("should parse args with strange spacing", () => {
             const parameterTokens = [" param1 :    int ", "  param2 ", "param3:List[int]"];


### PR DESCRIPTION
# Aim
I found a bug (reported in #143 ) where if you have some commented out sentence that contains the word "raise" would cause it to be parsed as if it was an Exception leading to this strange behaviour:
```python
def foo(bar):
    """[summary]

    Args:
        bar ([type]): [description]

    Raises:
        appropriate: [description]
    """
	print('Hello World')
	# TODO: raise appropriate error down the line
```

I modified the regex pattern to ignore raise if a "#" came at any point before it.

# How was this tested
Ran the example snippet provided above with expected behaviour. Ran it also with a good old Exception to see if I didn't just break the functionality all together
`npn run test` & `npm run integration_test` 

I didn't add a test to cover this particular case (I figured better to leave the current test be simple), but if you feel strongly about it I could!

# Related Issue
Fixes #143
