### PR TITLE
Discard lines that are only comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "autodocstring",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/parse/get_body.ts
+++ b/src/parse/get_body.ts
@@ -1,4 +1,4 @@
-import { blankLine, indentationOf } from "./utilities";
+import { blankLine, indentationOf, preprocessLines } from "./utilities";
 
 export function getBody(document: string, linePosition: number): string[] {
     const lines = document.split("\n");
@@ -19,11 +19,11 @@ export function getBody(document: string, linePosition: number): string[] {
             break;
         }
 
-        body.push(line.trim());
+        body.push(line);
         currentLineNum++;
     }
 
-    return body;
+    return preprocessLines(body);
 }
 
 function getBodyBaseIndentation(lines: string[], linePosition: number): number {

--- a/src/parse/get_definition.ts
+++ b/src/parse/get_definition.ts
@@ -1,4 +1,4 @@
-import { blankLine } from "./utilities";
+import { blankLine, preprocessLines } from "./utilities";
 
 export function getDefinition(document: string, linePosition: number): string {
     const precedingLines = getPrecedingLines(document, linePosition);
@@ -28,10 +28,9 @@ export function getDefinition(document: string, linePosition: number): string {
 
 function getPrecedingLines(document: string, linePosition: number): string[] {
     const lines = document.split("\n");
-    let precedingLines = lines.slice(0, linePosition);
+    const rawPrecedingLines = lines.slice(0, linePosition);
 
-    precedingLines = precedingLines.map((line) => line.trim());
-    precedingLines = precedingLines.filter((line) => !line.startsWith("#"));
+    const precedingLines = preprocessLines(rawPrecedingLines);
 
     return precedingLines;
 }

--- a/src/parse/utilities.ts
+++ b/src/parse/utilities.ts
@@ -8,6 +8,17 @@ export function getIndentation(line: string): string {
     return whiteSpaceMatches[0];
 }
 
+/**
+ * Preprocess an array of lines.
+ * For example trim spaces and discard comments
+ * @param lines The lines to preprocess.
+ */
+export function preprocessLines(lines: string[]): string[] {
+    return lines
+        .map(line => line.trim())
+        .filter((line) => !line.startsWith("#"));
+}
+
 export function indentationOf(line: string): number {
     return getIndentation(line).length;
 }

--- a/src/test/parse/get_body.spec.ts
+++ b/src/test/parse/get_body.spec.ts
@@ -26,6 +26,12 @@ describe("getBody()", () => {
         expect(result).to.have.deep.members(["print('HELLO WORLD')", "print('HELLO AGAIN')"]);
     });
 
+    it("should skip comment lines", () => {
+        const result = getBody(commentFunction, 5);
+
+        expect(result).to.have.deep.members(["print('HELLO AGAIN')"]);
+    });
+
     it("should handle multi line definitions", () => {
         const result = getBody(multiLineDefFunction, 4);
 
@@ -76,6 +82,16 @@ def gap_function():
 
     print('HELLO WORLD')
 
+    print('HELLO AGAIN')
+
+Something Else
+`;
+
+const commentFunction = `
+Something Else
+
+def gap_function():
+    # print('HELLO WORLD')
     print('HELLO AGAIN')
 
 Something Else

--- a/src/test/parse/utilities.spec.ts
+++ b/src/test/parse/utilities.spec.ts
@@ -1,7 +1,7 @@
 import chai = require("chai");
 import "mocha";
 
-import { getDefaultIndentation } from "../../parse";
+import { getDefaultIndentation, preprocessLines } from "../../parse/utilities";
 
 chai.config.truncateThreshold = 0;
 const expect = chai.expect;
@@ -27,5 +27,34 @@ describe("getDefaultIndentation()", () => {
         result = getDefaultIndentation(false, 8);
 
         expect(result).to.equal("\t");
+    });
+});
+
+describe("preprocessLines()", () => {
+    it('should trim lines passed.', () => {
+        const result = preprocessLines([
+            '    foo    ',
+            '\t\tbar\t\t',
+            '\r\rbatz\r\r',
+            '\t\rhello\t\r',
+            '\t\t    \r\t  world\t\r  \r\t  '
+        ]);
+        expect(result).to.be.deep.equal([
+            'foo',
+            'bar',
+            'batz',
+            'hello',
+            'world'
+        ]);
+    });
+
+    it('should discard comments.', () => {
+        const result = preprocessLines([
+            'foo',
+            '# hello world'
+        ]);
+        expect(result).to.be.deep.equal([
+            'foo'
+        ]);
     });
 });


### PR DESCRIPTION
# Description
Fixes #143 and introduces a more general approach than proposed by #144

# Changes
* Added a utility function to strip spaces and discard lines if they are pure comments (starting with `#`)
* Added unit tests

# Caveat
I think this PR is a step in the right direction but it won't solve the following sample:
For 
```python
def funcname(parameter_list):
        print('raise an exception') # yield something instead
```

The extension will still produce 
```python
def funcname(parameter_list):
    """
    [summary]

    Args:
        parameter_list ([type]): [description]

    Raises:
        an: [description]

    Yields:
        [type]: [description]
    """
    print('raise an exception') # yield something instead
```

Solving this issue is out of scope of this PR and we would need semantic information for example via the  [microsoft/python-language-server](https://github.com/Microsoft/python-language-server) 