### PR TITLE
Match quoted return type hint

### DIFF
--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -115,7 +115,7 @@ function parseYields(parameters: string[], body: string[]): Yields {
 }
 
 function parseReturnFromDefinition(parameters: string[]): Returns | null {
-    const pattern = /^->\s*([\w\[\], \.]*)/;
+    const pattern = /^->\s*(["']?)([\w\[\], \.]*)\1/;
 
     for (const param of parameters) {
         const match = param.trim().match(pattern);
@@ -125,7 +125,7 @@ function parseReturnFromDefinition(parameters: string[]): Returns | null {
         }
 
         // Skip "-> None" annotations
-        return match[1] === "None" ? null : { type: match[1] };
+        return match[1] === "None" ? null : { type: match[2] };
     }
 
     return null;

--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -125,7 +125,7 @@ function parseReturnFromDefinition(parameters: string[]): Returns | null {
         }
 
         // Skip "-> None" annotations
-        return match[1] === "None" ? null : { type: match[2] };
+        return match[2] === "None" ? null : { type: match[2] };
     }
 
     return null;

--- a/src/parse/tokenize_definition.ts
+++ b/src/parse/tokenize_definition.ts
@@ -1,5 +1,5 @@
 export function tokenizeDefinition(functionDefinition: string): string[] {
-    const definitionPattern = /(?:def|class)\s+\w+\s*\(([\s\S]*)\)\s*(->\s*[\w\[\], \.]*)?:\s*(?:#.*)?$/;
+    const definitionPattern = /(?:def|class)\s+\w+\s*\(([\s\S]*)\)\s*(->\s*(["']?)[\w\[\], \.]*\3)?:\s*(?:#.*)?$/;
 
     const match = definitionPattern.exec(functionDefinition);
     if (match == undefined || match[1] == undefined) {

--- a/src/test/parse/parse_parameters.spec.ts
+++ b/src/test/parse/parse_parameters.spec.ts
@@ -71,6 +71,22 @@ describe("parseParameters()", () => {
             });
         });
 
+        it("should parse return types wrapped in single quotes", () => {
+            expect(
+                parseParameters(["-> 'List[Type]'"], [], "name").returns
+            ).to.deep.equal({
+                type: "List[Type]"
+            });
+        });
+
+        it("should parse return types wrapped in double quotes", () => {
+            expect(
+                parseParameters(['-> "List[Type]"'], [], "name").returns
+            ).to.deep.equal({
+                type: "List[Type]"
+            });
+        });
+
         it("should not parse '-> None' return types", () => {
             const parameterTokens = ["-> None"];
             const result = parseParameters(parameterTokens, [], "name");


### PR DESCRIPTION
Allow the return type to be quoted.
See https://stackoverflow.com/a/33533514/11520125 under "Python <3.7: use a string".
This resolves issue #147