### PR TITLE
Remove inline comments during line preprocessing

### DIFF
--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -115,7 +115,7 @@ function parseYields(parameters: string[], body: string[]): Yields {
 }
 
 function parseReturnFromDefinition(parameters: string[]): Returns | null {
-    const pattern = /^->\s*([\w\[\], \.]*)/;
+    const pattern = /^->\s*(["']?)([\w\[\], \.]*)\1/;
 
     for (const param of parameters) {
         const match = param.trim().match(pattern);
@@ -125,7 +125,7 @@ function parseReturnFromDefinition(parameters: string[]): Returns | null {
         }
 
         // Skip "-> None" annotations
-        return match[1] === "None" ? null : { type: match[1] };
+        return match[1] === "None" ? null : { type: match[2] };
     }
 
     return null;

--- a/src/parse/tokenize_definition.ts
+++ b/src/parse/tokenize_definition.ts
@@ -1,5 +1,5 @@
 export function tokenizeDefinition(functionDefinition: string): string[] {
-    const definitionPattern = /(?:def|class)\s+\w+\s*\(([\s\S]*)\)\s*(->\s*[\w\[\], \.]*)?:\s*(?:#.*)?$/;
+    const definitionPattern = /(?:def|class)\s+\w+\s*\(([\s\S]*)\)\s*(->\s*(["']?)[\w\[\], \.]*\3)?:\s*(?:#.*)?$/;
 
     const match = definitionPattern.exec(functionDefinition);
     if (match == undefined || match[1] == undefined) {

--- a/src/parse/utilities.ts
+++ b/src/parse/utilities.ts
@@ -15,7 +15,7 @@ export function getIndentation(line: string): string {
  */
 export function preprocessLines(lines: string[]): string[] {
     return lines
-        .filter((line) => !line.startsWith("#"))
+        .filter((line) => !line.trim().startsWith("#"))
         .map(line => line.split("#")[0].trim());
 }
 

--- a/src/parse/utilities.ts
+++ b/src/parse/utilities.ts
@@ -15,7 +15,7 @@ export function getIndentation(line: string): string {
  */
 export function preprocessLines(lines: string[]): string[] {
     return lines
-        .map(line => line.trim())
+        .map(line => line.split("#")[0].trim())
         .filter((line) => !line.startsWith("#"));
 }
 

--- a/src/parse/utilities.ts
+++ b/src/parse/utilities.ts
@@ -15,8 +15,8 @@ export function getIndentation(line: string): string {
  */
 export function preprocessLines(lines: string[]): string[] {
     return lines
-        .map(line => line.split("#")[0].trim())
-        .filter((line) => !line.startsWith("#"));
+        .filter((line) => !line.startsWith("#"))
+        .map(line => line.split("#")[0].trim());
 }
 
 export function indentationOf(line: string): number {

--- a/src/test/parse/utilities.spec.ts
+++ b/src/test/parse/utilities.spec.ts
@@ -57,4 +57,19 @@ describe("preprocessLines()", () => {
             'foo'
         ]);
     });
+
+    it('should discard inline comments.', () => {
+        const result = preprocessLines([
+            'foo',
+            'arg: int # hello',
+            'hello#world',
+            'hello\t\t#world'
+        ]);
+        expect(result).to.be.deep.equal([
+            'foo',
+            'arg: int',
+            'hello',
+            'hello'
+        ]);
+    })
 });


### PR DESCRIPTION
Looks like the current implementation only removes lines that start with "#" to filter comments.
As described in issue #160, inline comments are missed. This should resolve issue #160.