### PR TITLE
add reStructuredText format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Visual Studio Code extension to quickly generate docstrings for python functions
 -   docBlockr
 -   Numpy
 -   Sphinx
+-   reStructuredText
 -   PEP0257 (coming soon)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "docstring",
         "google",
         "numpy",
+        "reStructuredText",
         "sphinx",
         "generator",
         "autodocstring",
@@ -75,7 +76,8 @@
                         "docblockr",
                         "google",
                         "sphinx",
-                        "numpy"
+                        "numpy",
+                        "reStructuredText"
                     ],
                     "description": "Which docstring format to use."
                 },

--- a/src/docstring/get_template.ts
+++ b/src/docstring/get_template.ts
@@ -8,6 +8,8 @@ export function getTemplate(docstringFormat: string): string {
             return getTemplateFile("sphinx.mustache");
         case "numpy":
             return getTemplateFile("numpy.mustache");
+        case "reStructuredText":
+            return getTemplateFile("reStructuredText.mustache");
         default:
             return getTemplateFile("default.mustache");
     }

--- a/src/docstring/templates/reStructuredText.mustache
+++ b/src/docstring/templates/reStructuredText.mustache
@@ -1,0 +1,25 @@
+{{! reStructuredText Docstring Template }}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+
+{{#args}}
+:param {{type}} {{var}}: {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+:param {{type}} {{var}}: {{descriptionPlaceholder}}. Defaults to {{&default}}.
+{{/kwargs}}
+{{#returns}}
+:return: {{descriptionPlaceholder}}
+:rtype: {{typePlaceholder}}
+{{/returns}}
+{{#yields}}
+:yield: {{descriptionPlaceholder}}
+:rtype: {{typePlaceholder}}
+{{/yields}}
+{{#exceptions}}
+:raises {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{#yields}}
+:yield: {{type}} {{descriptionPlaceholder}}
+{{/yields}}

--- a/src/test/docstring/get_template.spec.ts
+++ b/src/test/docstring/get_template.spec.ts
@@ -31,6 +31,14 @@ describe("getTemplate()", () => {
         });
     });
 
+    context("when asked for reStructuredText template", () => {
+        it("should return the string containing the reStructuredText mustache template", () => {
+            const result = getTemplate("reStructuredText");
+
+            expect(result).to.contain("reStructuredText Docstring Template");
+        });
+    });
+
     context("when asked for anything else", () => {
         it("should return the string containing the default mustache template", () => {
             const result = getTemplate("blah");


### PR DESCRIPTION
add reStructuredText format.

![demo](https://user-images.githubusercontent.com/2500024/96324085-d31e2000-105a-11eb-9bf3-6ace2b3f915f.gif)

I  refered following sample in https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists.

```
.. py:function:: send_message(sender, recipient, message_body, [priority=1])

   Send a message to a recipient

   :param str sender: The person sending the message
   :param str recipient: The recipient of the message
   :param str message_body: The body of the message
   :param priority: The priority of the message, can be a number 1-5
   :type priority: integer or None
   :return: the message id
   :rtype: int
   :raises ValueError: if the message_body exceeds 160 characters
   :raises TypeError: if the message_body is not a basestring
```

note. 
This PR don't still support `type `. But I think it is enough useful currently even if `type` is not supported.