### PR TITLE
resolves #181 Add AssertionError

### DIFF
--- a/src/parse/parse_parameters.ts
+++ b/src/parse/parse_parameters.ts
@@ -133,9 +133,22 @@ function parseReturnFromDefinition(parameters: string[]): Returns | null {
 
 function parseExceptions(body: string[]): Exception[] {
     const exceptions: Exception[] = [];
-    const pattern = /(?<!#.*)raise\s+([\w.]+)/;
 
+    // Add "assert" exceptions
     for (const line of body) {
+        const pattern = /(?<!#.*)assert\s+/;
+        const match = line.match(pattern);
+
+        if (match == null) {
+            continue;
+        }
+
+        exceptions.push({ type: "AssertionError" });
+    }
+
+    // Add "raise" exceptions
+    for (const line of body) {
+        const pattern = /(?<!#.*)raise\s+([\w.]+)/;
         const match = line.match(pattern);
 
         if (match == null) {


### PR DESCRIPTION
This PR resolves #181.

It adds a second loop to the `parseExceptions()` function, which searches for a different pattern (`/(?<!#.*)assert\s+/`), and adds each to the list of exceptions.

The assert loop is run first, because `assert`'s are usually at the beginning of functions, while `raise`'s are usually later.