### PR TITLE
Fix length of underline for Yields section in numpy style docstrings

### DIFF
--- a/src/docstring/templates/numpy.mustache
+++ b/src/docstring/templates/numpy.mustache
@@ -27,7 +27,7 @@ Returns
 
 {{#yieldsExist}}
 Yields
--------
+------
 {{#yields}}
 {{typePlaceholder}}
     {{descriptionPlaceholder}}


### PR DESCRIPTION
There is one additional dash in the underline of the Yields section for numpy style docstrings, compared to the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#yields). This is detected by flake8 as `D409 Section underline should match the length of its name`, would probably not have noticed this myself otherwise 😄.

Thanks for this awesome extension!
