### PR TITLE
add oneline-rst docstring to menu and readme so its accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Visual Studio Code extension to quickly generate docstrings for python functions
 -   docBlockr
 -   Numpy
 -   Sphinx
+-   oneline-rst
 -   PEP0257 (coming soon)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
                         "docblockr",
                         "google",
                         "sphinx",
-                        "numpy"
+                        "numpy",
+                        "oneline-rst"
                     ],
                     "description": "Which docstring format to use."
                 },


### PR DESCRIPTION
Thanks for making this extension, @NilsJPWerner. 
This pr exposes `oneline-rst` docstring format, added in PR: https://github.com/NilsJPWerner/autoDocstring/pull/169,  in the settings dropdown to make it accessible to users.