### PR TITLE
Google style docstring template without type hints (PEP 484)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "autodocstring",
     "displayName": "Python Docstring Generator",
     "description": "Automatically generates detailed docstrings for python functions",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "publisher": "njpwerner",
     "license": "SEE LICENSE IN LICENSE",
     "icon": "images/icon.png",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
                     "enum": [
                         "docblockr",
                         "google",
+                        "google-notypes",
                         "sphinx",
                         "numpy"
                     ],

--- a/src/docstring/get_template.ts
+++ b/src/docstring/get_template.ts
@@ -4,6 +4,8 @@ export function getTemplate(docstringFormat: string): string {
     switch (docstringFormat) {
         case "google":
             return getTemplateFile("google.mustache");
+        case "google-notypes":
+            return getTemplateFile("google-notypes.mustache");
         case "sphinx":
             return getTemplateFile("sphinx.mustache");
         case "numpy":

--- a/src/docstring/templates/google-notypes.mustache
+++ b/src/docstring/templates/google-notypes.mustache
@@ -1,0 +1,35 @@
+{{! Google Docstring Template }}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+
+{{#parametersExist}}
+Args:
+{{#args}}
+    {{var}}: {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+    {{var}}: {{descriptionPlaceholder}}. Defaults to {{&default}}.
+{{/kwargs}}
+{{/parametersExist}}
+
+{{#exceptionsExist}}
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{/exceptionsExist}}
+
+{{#returnsExist}}
+Returns:
+{{#returns}}
+    {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+
+{{#yieldsExist}}
+Yields:
+{{#yields}}
+    {{descriptionPlaceholder}}
+{{/yields}}
+{{/yieldsExist}}

--- a/src/docstring/templates/google-notypes.mustache
+++ b/src/docstring/templates/google-notypes.mustache
@@ -1,4 +1,4 @@
-{{! Google Docstring Template }}
+{{! Google Docstring Template without Types for Args, Returns or Yields }}
 {{summaryPlaceholder}}
 
 {{extendedSummaryPlaceholder}}

--- a/src/test/docstring/get_template.spec.ts
+++ b/src/test/docstring/get_template.spec.ts
@@ -15,6 +15,14 @@ describe("getTemplate()", () => {
         });
     });
 
+    context("when asked for google-notypes template", () => {
+        it("should return the string containing the google mustache template", () => {
+            const result = getTemplate("google-notypes");
+
+            expect(result).to.contain("Google Docstring Template without Types for Args, Returns or Yields");
+        });
+    });
+
     context("when asked for sphinx template", () => {
         it("should return the string containing the sphinx mustache template", () => {
             const result = getTemplate("sphinx");


### PR DESCRIPTION
This PR follows from a personal need to avoid type hints in google-style docstrings due to them being harder to maintain and redundant after [PEP-484](https://www.python.org/dev/peps/pep-0484/).
I believe the introduction of this template to be a benefit teams/projects that use this extension during development.
This way everyone has the template already installed with the extension and they don't have to further configure a custom template.

Thus, this PR introduces the `google-notypes` choice in the extension's `Docstring Format` drop-down menu in the extension settings. This new template is pretty much a copy of the default `google` template, with the removal of the type hints from inside the docstrings.


I successfully run all available tests locally and I installed the compiled `.vsix` package in my own local Visual Studio Code (v1.63.1) and tested that it works.

Please let me know if I missed something.
I've never worked with TypeScript before, but I am a little bit familiar with `node` and `npm`.

This should also solve #121 