### PR TITLE
🩹 Fix yield underline in numpy template

### DIFF
--- a/src/docstring/templates/numpy.mustache
+++ b/src/docstring/templates/numpy.mustache
@@ -27,7 +27,7 @@ Returns
 
 {{#yieldsExist}}
 Yields
--------
+------
 {{#yields}}
 {{typePlaceholder}}
     {{descriptionPlaceholder}}


### PR DESCRIPTION
The Yields section in the numpy template has an additional dash linters complain about.