### PR TITLE
Add template google-notypes-nodefault

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
                         "pep257",
                         "google",
                         "google-notypes",
+                        "google-notypes-nodefault",
                         "sphinx",
                         "sphinx-notypes",
                         "numpy",

--- a/src/docstring/templates/google-notypes-nodefault.mustache
+++ b/src/docstring/templates/google-notypes-nodefault.mustache
@@ -1,0 +1,35 @@
+{{! Google Docstring Template without Types for Args, Returns or Yields and without naming the default for kwargs}}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+{{#parametersExist}}
+
+Args:
+{{#args}}
+    {{var}}: {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+    {{var}}: {{descriptionPlaceholder}}
+{{/kwargs}}
+{{/parametersExist}}
+{{#exceptionsExist}}
+
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{/exceptionsExist}}
+{{#returnsExist}}
+
+Returns:
+{{#returns}}
+    {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+{{#yieldsExist}}
+
+Yields:
+{{#yields}}
+    {{descriptionPlaceholder}}
+{{/yields}}
+{{/yieldsExist}}


### PR DESCRIPTION
This is the same template as google-notypes just without having "Defaults to x" for kwargs. The reason for adding this is that the default value for the kwargs is already contained in the function declaration so having it repeated in the docstring is redundant and can lead to divergence. 