### PR TITLE
Add template for MkDocs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To turn off type generation in docstrings use the `-notypes` template of the des
 -   [docBlockr](docs/docblockr.md)
 -   [one-line-sphinx](docs/one-line-sphinx.md)
 -   [pep257](docs/pep257.md)
+-   [mkdocs](docs/mkdocs.md)
 
 ## Usage
 

--- a/docs/mkdocs.md
+++ b/docs/mkdocs.md
@@ -1,0 +1,30 @@
+# MkDocs Docstring Format
+
+```python
+def abc(a: int, c = [1,2]):
+    """_summary_
+    
+    
+    
+    #### Args
+    > ##### `a: int`
+    > _description_
+    
+    > ##### `c: list = [1,2]`
+    > _description_
+    
+    
+    #### Raises
+    > ##### `AssertionError`
+    > _description_
+    
+    
+    #### Returns
+    > ##### `_type_`
+    > _description_
+    """
+    if a > 10:
+        raise AssertionError("a is more than 10")
+
+    return c
+```

--- a/src/docstring/templates/mkdocs.mustache
+++ b/src/docstring/templates/mkdocs.mustache
@@ -1,0 +1,43 @@
+{{! MkDocs Docstring Template }}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+{{#parametersExist}}
+
+#### Args
+{{#args}}
+> ##### `{{var}}: {{typePlaceholder}}`
+> {{descriptionPlaceholder}}
+
+{{/args}}
+{{#kwargs}}
+> ##### `{{var}}: {{typePlaceholder}} = {{&default}}`
+> {{descriptionPlaceholder}}
+
+{{/kwargs}}
+{{/parametersExist}}
+{{#exceptionsExist}}
+
+#### Raises
+{{#exceptions}}
+> ##### `{{type}}`
+> {{descriptionPlaceholder}}
+
+{{/exceptions}}
+{{/exceptionsExist}}
+{{#returnsExist}}
+
+#### Returns
+{{#returns}}
+> ##### `{{typePlaceholder}}`
+> {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+{{#yieldsExist}}
+
+#### Yields
+{{#yields}}
+> ##### `{{typePlaceholder}}`
+> {{descriptionPlaceholder}}
+{{/yields}}
+{{/yieldsExist}}


### PR DESCRIPTION
Writes docs in markdown syntax, in the style of [MkDocs](https://www.mkdocs.org/dev-guide/api/)