### PR TITLE
Add improved concatenation of the representation string

### DIFF
--- a/src/docstring/template_data.ts
+++ b/src/docstring/template_data.ts
@@ -76,7 +76,7 @@ export class TemplateData {
     }
 
     public descriptionPlaceholder(): string {
-        return "${@@@:_description_}";
+        return "- " + "${@@@:_description_}";
     }
 
     public argsExist(): boolean {


### PR DESCRIPTION
Hi, Nils!
I'm currently learning programming and very often use your extension 'autoDocstring' on VScode.
I noticed if description docstring will be like bulleted listt, its better visually.
Please, consider my remark. As the writer Robert Martin writes in his book 'Clean code' - <Honesty in small things is not a trifle at all>

Ps. A have 2 screenshots that show the difference in the visualization of the description
1. Before https://ibb.co/Wf5ndFs
2. After https://ibb.co/MB8gpB4

Thank you for your attention and have a nice day))!