### PR TITLE
Change the mustache, HTML-escaping behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Added doxygen format support ([#120](https://github.com/NilsJPWerner/autoDocstring/issues/120)) (@daluar @PhilipNelson5)
+-   Disable HTML-escaping behavior globally ([#253](https://github.com/NilsJPWerner/autoDocstring/issues/253)) (@PhilipNelson5)
 
 [All Changes](https://github.com/NilsJPWerner/autoDocstring/compare/v0.6.1...master)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 -   Added doxygen format support ([#120](https://github.com/NilsJPWerner/autoDocstring/issues/120)) (@daluar @PhilipNelson5)
--   Disable HTML-escaping behavior globally ([#253](https://github.com/NilsJPWerner/autoDocstring/issues/253)) (@PhilipNelson5)
+-   Disable HTML-escaping behavior globally ([#235](https://github.com/NilsJPWerner/autoDocstring/issues/235)) (@PhilipNelson5)
 
 [All Changes](https://github.com/NilsJPWerner/autoDocstring/compare/v0.6.1...master)
 

--- a/src/docstring/docstring_factory.ts
+++ b/src/docstring/docstring_factory.ts
@@ -2,6 +2,10 @@ import { render } from "mustache";
 import { DocstringParts } from "../docstring_parts";
 import { TemplateData } from "./template_data";
 import { dedent } from "ts-dedent";
+import Mustache = require("mustache");
+
+// Disable HTML-escaping behavior globally
+Mustache.escape = (text: string) => text;
 
 export class DocstringFactory {
     private template: string;

--- a/src/test/docstring/generate_docstring.spec.ts
+++ b/src/test/docstring/generate_docstring.spec.ts
@@ -260,6 +260,22 @@ describe("DocstringFactory", () => {
             });
         });
 
+        context("when there are args", () => {
+            const template = "{{#args}}{{var}}:{{typePlaceholder}}{{/args}}";
+
+            it("should format Literals correctly", () => {
+                const docstringComponents = defaultDocstringComponents;
+                docstringComponents.args = [
+                    { var: "var_a", type: 'Literal["A", "B"]' },
+                ];
+                const factory = new DocstringFactory(template);
+
+                const result = factory.generateDocstring(docstringComponents);
+
+                expect(result).to.equal('"""var_a:${1:Literal["A", "B"]}"""');
+            });
+        });
+
         context("when the argsExist tag is used", () => {
             const template = "{{#argsExist}}Args Exist!{{/argsExist}}";
 


### PR DESCRIPTION
HTML-escaping quotes is a feature of mustache, see janl/mustache.js#13 and the [variables](https://github.com/janl/mustache.js?tab=readme-ov-file#variables) section in the docs. 

> All variables are HTML-escaped by default

The recommendation to disable HTML-escaping is

> If you'd like to change HTML-escaping behavior globally (for example, to template non-HTML formats), you can override Mustache's escape function. For example, to disable all escaping: `Mustache.escape = function(text) {return text;};`.

closes #235