### PR TITLE
Improve class and function definition identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Added doxygen format support ([#120](https://github.com/NilsJPWerner/autoDocstring/issues/120)) (@daluar @PhilipNelson5)
+-   Improve definition detection to allow reserved words in the default arguments ([#190](https://github.com/NilsJPWerner/autoDocstring/issues/190)) (@ylfzq @PhilipNelson5)
 
 [All Changes](https://github.com/NilsJPWerner/autoDocstring/compare/v0.6.1...master)
 

--- a/src/parse/get_definition.ts
+++ b/src/parse/get_definition.ts
@@ -10,12 +10,15 @@ export function getDefinition(document: string, linePosition: number): string {
         return "";
     }
 
-    const pattern = /\b(((async\s+)?\s*def)|\s*class)\b/g;
+    // Match (async)? def name (...) and class name (...)
+    const pattern = /\b(((async\s+)?\s*def)|\s*class)\s+\w+\s*\(.*?\)/g;
 
-    // Get starting index of last def match in the preceding text
+    // Get starting index of last def or class match in the preceding text
     let index: number;
-    while (pattern.test(precedingText)) {
-        index = pattern.lastIndex - RegExp.lastMatch.length;
+    let match = pattern.exec(precedingText);
+    while (match) {
+        index = match.index;
+        match = pattern.exec(precedingText);
     }
 
     if (index == undefined) {

--- a/src/test/parse/get_definition.spec.ts
+++ b/src/test/parse/get_definition.spec.ts
@@ -14,6 +14,12 @@ describe("getDefinition()", () => {
             expect(result).to.equal("def basic_function(param1, param2 = abc):");
         });
 
+        it("should get a function definition that uses reserved words as default arguments", () => {
+            const result = getDefinition(functionWithReservedWordDefaults, 10);
+
+            expect(result).to.equal('def function_with_reserved_word_defaults( a: int, b="def", c="class" ) -> None:');
+        });
+
         it("should get an indented function definition", () => {
             const result = getDefinition(indentedFunction, 4);
 
@@ -82,6 +88,20 @@ def basic_function(param1, param2 = abc):
     return 3
 
 def something_else():
+`;
+
+const functionWithReservedWordDefaults = `
+def another_func(a: str = "class, b: int): -> str
+    return a
+
+class Foo(object):
+    pass
+
+def function_with_reserved_word_defaults(
+    a: int, b="def", c="class"
+) -> None:
+    """
+    pass
 `;
 
 const indentedFunction = `


### PR DESCRIPTION
If a function uses the words `class` or `def` in it's signature, it breaks the definition identification. This expands the match to include the function/class name and arguments to disambiguate this case.

closes #190 