### PR TITLE
fix: update google-notypes.mustache

### DIFF
--- a/src/docstring/templates/google-notypes.mustache
+++ b/src/docstring/templates/google-notypes.mustache
@@ -1,35 +1,35 @@
 {{! Google Docstring Template without Types for Args, Returns or Yields }}
-{{summaryPlaceholder}}
+{{summaryPlaceholder}}.
 
 {{extendedSummaryPlaceholder}}
 {{#parametersExist}}
 
 Args:
 {{#args}}
-    {{var}}: {{descriptionPlaceholder}}
+    {{var}}: {{descriptionPlaceholder}}.
 {{/args}}
 {{#kwargs}}
     {{var}}: {{descriptionPlaceholder}}. Defaults to {{&default}}.
 {{/kwargs}}
 {{/parametersExist}}
-{{#exceptionsExist}}
-
-Raises:
-{{#exceptions}}
-    {{type}}: {{descriptionPlaceholder}}
-{{/exceptions}}
-{{/exceptionsExist}}
 {{#returnsExist}}
 
 Returns:
 {{#returns}}
-    {{descriptionPlaceholder}}
+    {{descriptionPlaceholder}}.
 {{/returns}}
 {{/returnsExist}}
+{{#exceptionsExist}}
+
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}.
+{{/exceptions}}
+{{/exceptionsExist}}
 {{#yieldsExist}}
 
 Yields:
 {{#yields}}
-    {{descriptionPlaceholder}}
+    {{descriptionPlaceholder}}.
 {{/yields}}
 {{/yieldsExist}}


### PR DESCRIPTION
Following the Google style guide examples, e.g., under the [Functions and Methods](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) section, this PR moves the `Raises` section below the `Returns` section and adds `.` after placeholders.